### PR TITLE
image background not covering height in android chrome fixed

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -10,9 +10,12 @@ html {
   font-family: sans-serif;
   -webkit-text-size-adjust: 100%;
       -ms-text-size-adjust: 100%;
+    height:100%;
+    min-height:100%;
 }
 
 body { 
+    min-height:100%;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 /*    background: rgb(23,0,82);*/
 /*    background: #161675;*/


### PR DESCRIPTION
http://stackoverflow.com/questions/14876035/background-size-cover-not-working-in-portrait-on-android-tablet
